### PR TITLE
Correctly handle IAC byte escaping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/*.rs.bk
 Cargo.lock
 .tags*
+.idea


### PR DESCRIPTION
I noticed that IAC character escaping (double `0xFF`) was not working quite correctly. The buffer in the event returned after the escaped IAC character was re-copying data because `data_start` was not being updated.

I've added a test to `lib.rs` to verify the fix.