### PR TITLE
runtime switchable zlib stream.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "telnet"
 description = "A simple implementation of telnet protocol."
-version = "0.1.3"
+version = "0.1.4"
 authors = ["SLMT <sam123456777@gmail.com>"]
 readme = "README.md"
 homepage = "https://github.com/SLMT/telnet-rs"
@@ -12,3 +12,8 @@ keywords = ["telnet"]
 categories = ["network-programming"]
 
 [dependencies]
+flate2 = { version = "1.0.9", optional = true }
+replace_with = { version = "0.1.3", optional = true }
+
+[features]
+zcstream = ["flate2", "replace_with"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,23 @@
 
+//! #### MCCP2
+//! A feature of some telnet servers is `MCCP2` which allows the downstream data to be compressed.
+//! To use this, first enable the `zcstream` [rust feature](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section) for this crate.
+//! Then in the code deal with the relevant events, and switch the zlib when appropriate.
+//!
+//! Basic usage example:
+//! ```
+//! match event {
+//! 	TelnetEvent::Data(buffer) => {
+//! 		println!("{}", &std::str::from_utf8(&(*buffer)).unwrap());
+//! 	},
+//! 	TelnetEvent::Negotiation(NegotiationAction::Will, TelnetOption::Compress2) => {
+//! 		telnet.negotiate(NegotiationAction::Do, TelnetOption::Compress2);
+//! 	},
+//! 	TelnetEvent::Subnegotiation(TelnetOption::Compress2, _) => {
+//! 		telnet.begin_zlib();
+//! 	}
+//! }
+//! ```
 mod negotiation;
 mod option;
 mod event;
@@ -57,25 +76,6 @@ enum ProcessState {
 /// }
 /// ```
 ///
-/// # MCCP2
-/// A feature of some telnet servers is `MCCP2` which allows the downstream data to be compressed.
-/// To use this, first enable the `zcstream` [rust feature](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section) for this crate.
-/// Then in the code deal with the relevant events, and switch the zlib when appropriate.
-///
-/// Basic usage example:
-/// ```
-/// match event {
-/// 	TelnetEvent::Data(buffer) => {
-/// 		println!("{}", &std::str::from_utf8(&(*buffer)).unwrap());
-/// 	},
-/// 	TelnetEvent::Negotiation(NegotiationAction::Will, TelnetOption::Compress2) => {
-/// 		telnet.negotiate(NegotiationAction::Do, TelnetOption::Compress2);
-/// 	},
-/// 	TelnetEvent::Subnegotiation(TelnetOption::Compress2, _) => {
-/// 		telnet.begin_zlib();
-/// 	}
-/// }
-/// ```
 pub struct Telnet {
     stream: Box<TStream>,
     event_queue: TelnetEventQueue,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,25 @@ enum ProcessState {
 /// }
 /// ```
 ///
+/// # MCCP2
+/// A feature of some telnet servers is `MCCP2` which allows the downstream data to be compressed.
+/// To use this, first enable the `zcstream` [rust feature](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section) for this crate.
+/// Then in the code deal with the relevant events, and switch the zlib when appropriate.
+///
+/// Basic usage example:
+/// ```
+/// match event {
+/// 	TelnetEvent::Data(buffer) => {
+/// 		println!("{}", &std::str::from_utf8(&(*buffer)).unwrap());
+/// 	},
+/// 	TelnetEvent::Negotiation(NegotiationAction::Will, TelnetOption::Compress2) => {
+/// 		telnet.negotiate(NegotiationAction::Do, TelnetOption::Compress2);
+/// 	},
+/// 	TelnetEvent::Subnegotiation(TelnetOption::Compress2, _) => {
+/// 		telnet.begin_zlib();
+/// 	}
+/// }
+/// ```
 pub struct Telnet {
     stream: Box<TStream>,
     event_queue: TelnetEventQueue,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,11 @@ mod zcstream;
 #[cfg(feature = "zcstream")]
 mod zlibstream;
 
+pub use stream::Stream;
+#[cfg(feature = "zcstream")]
+pub use zlibstream::ZlibStream;
+#[cfg(feature = "zcstream")]
+pub use zcstream::ZCStream;
 pub use option::TelnetOption;
 pub use event::TelnetEvent;
 pub use negotiation::NegotiationAction;
@@ -20,13 +25,11 @@ use std::time::Duration;
 
 use event::TelnetEventQueue;
 use byte::*;
-#[cfg(feature = "zcstream")]
-use zlibstream::ZlibStream;
 
 #[cfg(feature = "zcstream")]
-pub type Stream = zcstream::ZCStream;
+type TStream = zcstream::ZCStream;
 #[cfg(not(feature = "zcstream"))]
-pub type Stream = stream::Stream;
+type TStream = stream::Stream;
 
 #[derive(Debug)]
 enum ProcessState {
@@ -55,7 +58,7 @@ enum ProcessState {
 /// ```
 ///
 pub struct Telnet {
-    stream: Box<Stream>,
+    stream: Box<TStream>,
     event_queue: TelnetEventQueue,
 
     // Buffer
@@ -107,7 +110,7 @@ impl Telnet {
     /// 
     /// Use this version of the constructor if you want to provide your own stream, for example if you want
     /// to mock out the remote host for testing purposes, or want to wrap the data the data with TLS encryption.
-    pub fn from_stream(stream: Box<Stream>, buf_size: usize) -> Telnet {
+    pub fn from_stream(stream: Box<TStream>, buf_size: usize) -> Telnet {
         let actual_size = if buf_size == 0 { 1 } else { buf_size };
 
         Telnet {

--- a/src/zcstream.rs
+++ b/src/zcstream.rs
@@ -1,5 +1,6 @@
 use stream::Stream;
 
+/// Stream with ability to be upgraded to zlib stream.
 pub trait ZCStream: Stream {
     /// Begin zlib decompression on downstream. Ignored if already enabled.
     fn begin_zlib(&mut self);

--- a/src/zcstream.rs
+++ b/src/zcstream.rs
@@ -1,6 +1,8 @@
 use stream::Stream;
 
 pub trait ZCStream: Stream {
+    /// Begin zlib decompression on downstream. Ignored if already enabled.
     fn begin_zlib(&mut self);
+    /// Stop zlib decompression on downstream. Ignored if already disabled.
     fn end_zlib(&mut self);
 }

--- a/src/zcstream.rs
+++ b/src/zcstream.rs
@@ -1,0 +1,6 @@
+use stream::Stream;
+
+pub trait ZCStream: Stream {
+    fn begin_zlib(&mut self);
+    fn end_zlib(&mut self);
+}

--- a/src/zlibstream.rs
+++ b/src/zlibstream.rs
@@ -12,6 +12,15 @@ enum ZlibStreamSwitch<T> {
     Encoded(ZlibDecoder<T>)
 }
 
+///
+/// A wrapper which can enable and disable zlib decompression for downstream at runtime.
+///
+/// # Examples
+///
+/// ```
+/// let mut stream = ZlibStream::from_stream(old_stream);
+/// stream.begin_zlib();
+/// ```
 pub struct ZlibStream<T> {
     stream: ZlibStreamSwitch<T>
 }

--- a/src/zlibstream.rs
+++ b/src/zlibstream.rs
@@ -1,0 +1,83 @@
+extern crate flate2;
+extern crate replace_with;
+
+use std::time::Duration;
+use std::io::{Read, Write, Result};
+use zlibstream::flate2::read::ZlibDecoder;
+use stream::Stream;
+use zcstream::ZCStream;
+
+enum ZlibStreamSwitch<T> {
+    Plain(T),
+    Encoded(ZlibDecoder<T>)
+}
+
+pub struct ZlibStream<T> {
+    stream: ZlibStreamSwitch<T>
+}
+
+impl <T> ZlibStream<T> where T: Read {
+    pub fn from_stream(stream: T) -> Self {
+        ZlibStream::<T>{stream: ZlibStreamSwitch::Plain(stream)}
+    }
+}
+
+
+impl <T> Read for ZlibStream<T> where T: Read {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        match self.stream {
+            ZlibStreamSwitch::Plain(ref mut stream) => stream.read(buf),
+            ZlibStreamSwitch::Encoded(ref mut stream) => stream.read(buf)
+        }
+    }
+}
+
+impl <T> Write for ZlibStream<T> where T: Write {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        match self.stream {
+            ZlibStreamSwitch::Plain(ref mut stream) => stream.write(buf),
+            ZlibStreamSwitch::Encoded(ref mut stream) => stream.get_mut().write(buf)
+        }
+    }
+    fn flush(&mut self) -> Result<()> {
+        match self.stream {
+            ZlibStreamSwitch::Plain(ref mut stream) => stream.flush(),
+            ZlibStreamSwitch::Encoded(ref mut stream) => stream.get_mut().flush()
+        }
+    }
+}
+
+impl <T> Stream for ZlibStream<T> where T: Stream {
+    fn set_nonblocking(&self, nonblocking: bool) -> Result<()> {
+        match self.stream {
+            ZlibStreamSwitch::Plain(ref stream) => stream.set_nonblocking(nonblocking),
+            ZlibStreamSwitch::Encoded(ref stream) => stream.get_ref().set_nonblocking(nonblocking)
+        }
+    }
+
+    fn set_read_timeout(&self, dur: Option<Duration>) -> Result<()> {
+        match self.stream {
+            ZlibStreamSwitch::Plain(ref stream) => stream.set_read_timeout(dur),
+            ZlibStreamSwitch::Encoded(ref stream) => stream.get_ref().set_read_timeout(dur)
+        }
+    }
+}
+
+impl <T> ZCStream for ZlibStream<T> where T: Stream {
+    fn begin_zlib(&mut self) {
+        replace_with::replace_with_or_abort(&mut self.stream, |stream| 
+            match stream {
+                ZlibStreamSwitch::Plain(stream) => ZlibStreamSwitch::Encoded(ZlibDecoder::new(stream)),
+                e => e
+            }
+        )
+    }
+    fn end_zlib(&mut self) {
+        replace_with::replace_with_or_abort(&mut self.stream, |stream| 
+            match stream {
+                ZlibStreamSwitch::Encoded(stream) => ZlibStreamSwitch::Plain(stream.into_inner()),
+                p => p
+            }
+        )
+    }
+}


### PR DESCRIPTION
Added Ability - as compile time feature -  to have a zlib stream wrap the Stream (including the telnet negotiations) at runtime.

This cannot be done using #2 's Stream, since the Stream needs to be switched at runtime - and it is moved into Telnet. (which only knows about it as Stream, and does not know how to switch it)

This is used for MCCP2=Compress2, which seems to be the only telnet negotiation which makes changes to the stream itself.

(Even as a compile time feature, not completely sure if this should be in main crate, or just stay as local change)