### PR TITLE
don't test MCCP2 example code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! Then in the code deal with the relevant events, and switch the zlib when appropriate.
 //!
 //! Basic usage example:
-//! ```
+//! ```ignore
 //! match event {
 //! 	TelnetEvent::Data(buffer) => {
 //! 		println!("{}", &std::str::from_utf8(&(*buffer)).unwrap());


### PR DESCRIPTION
#6 seems to fail in the tests so:
Added `ignore` to MCCP2 example code, as it shouldn't be tested without the feature on.
(It is possible to have the same doc twice, and only ignore without the feature on, I don't think it is worth it)