### PR TITLE
Add connect_timeout method to Telnet struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,17 +125,18 @@ impl Telnet {
         #[cfg(not(feature = "zcstream"))]
         return Ok(Telnet::from_stream(Box::new(stream), buf_size));
     }
-    /// Like [`Telnet::connect`] but must be passed a timeout [`Duration`]. Uses a [`TcpStream::connect_timeout`] under the hood
-    /// and so can only be passed a single address of type [`SocketAddr`]
+    /// Opens a telnet connection to a remote host using a TcpStream with a timeout [`Duration`]. Uses a [`TcpStream::connect_timeout`] under the hood
+    /// and so can only be passed a single address of type [`SocketAddr`], and passing a zero [`Duration`] results in an error.
     /// # Examples
     /// ```rust,should_panic
     /// use telnet::Telnet;
     /// use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     /// use std::str::FromStr;
     /// use std::time::Duration;
-    /// let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::from_str("127.0.0.1").expect("Invalid address")), 23);
+    /// let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::from_str("127.0.0.1")
+    ///                                 .expect("Invalid address")), 23);
     /// let telnet = Telnet::connect_timeout(&address, 256, Duration::from_secs(2))
-    ///                                          .expect("Couldn't connect to the server...");
+    ///                                 .expect("Couldn't connect to the server...");
     /// ```
     ///
     /// # Errors


### PR DESCRIPTION
First up, thanks for this crate! It's been very helpful. 

One thing that would be great to have, to pair with the read_timeout, is a timeout on connect. I'm no TcpStream expert but i assume if they have a separate method for connecting with a timeout then the vanilla method will just sit forever waiting.

The downside of this is it is a straight passthrough to the connect_timeout method, which explicitly takes a `SocketAddr` which isn't as ergonomic. For example we might have to build an address with something like this now
```rust
use std::net::{IpAddr, Ipv4Addr, SocketAddr};
use std::str::FromStr;
let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::from_str(ADDRESS)?), PORT);
let mut telnet = Telnet::connect_timeout(address, 1024, Duration::from_secs(2))?;
```

I'm open to trying to make this better by adapting that so that the inputs could be more or less the same but i thought i'd see what people thought with the super simple passthrough case first.