### PR TITLE
adds requirement for Send + Sync to `dyn Stream`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,9 +55,9 @@ use std::{
 };
 
 #[cfg(feature = "zcstream")]
-type TStream = dyn zcstream::ZCStream;
+type TStream = dyn zcstream::ZCStream + Send + Sync;
 #[cfg(not(feature = "zcstream"))]
-type TStream = dyn stream::Stream;
+type TStream = dyn stream::Stream + Send + Sync;
 
 #[derive(Debug)]
 enum ProcessState {


### PR DESCRIPTION
The lack of requiring the stream trait to be Send and Sync made Telnet itself neither Send nor Sync, despite actually being Send and Sync.